### PR TITLE
Fixes InsecureRequestWarning message

### DIFF
--- a/adp_connection/lib/adpapiconnection.py
+++ b/adp_connection/lib/adpapiconnection.py
@@ -94,8 +94,7 @@ class ADPAPIConnection(object):
                                     self.getConfig().getSSLKeyPath()),
                               auth=(self.getConfig().getClientID(),
                                     self.getConfig().getClientSecret()),
-                              data=(formData),
-                              verify=False)
+                              data=(formData))
             logging.debug(r.status_code)
             logging.debug(r.json())
             if (r.status_code == requests.codes.ok):
@@ -192,7 +191,7 @@ class AuthorizationCodeConnection(ADPAPIConnection):
                                 self.getConfig().getSSLKeyPath()),
                           data=(formData),
                           verify=False)
-        
+
         logging.debug(r.status_code)
         logging.debug(r.json())
         if (r.status_code == requests.codes.ok):


### PR DESCRIPTION
#4 
Verification was set to False but that has been changed to default True value.
ADP recommends using certificates from getting tokens - otherwise they might slow down issuing of tokens and/or communication with their servers